### PR TITLE
Feature/clear submit form

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
                 </div>
               </section>
             <button id="submit-guess-btn" type="button">SUBMIT GUESS</button>
-            <button type="button">RESET GAME</button>
+            <button id="reset-game-btn" type="button">RESET GAME</button>
             <button id="clear-form-btn"type="button">CLEAR FORM</button>
           </form>
         </section>

--- a/main.js
+++ b/main.js
@@ -12,20 +12,25 @@ submitGuessForm.addEventListener('input', enableClearBtn);
 clearFormBtn.addEventListener('click', clearFormInputs);
 submitBtn.addEventListener('click', populateLatestGuess);
 
+
 function checkGuessInputs(){
 
   if (challenger1Name.value && challenger1Guess.value && challenger2Name.value && challenger2Guess.value){
     submitBtn.disabled === false;
+    console.log('submit-btn-not-disabled');
   } else {
     submitBtn.disabled=== true;
+    console.log('submit-btn-not-disabled');
   }
 }
 
 function enableClearBtn() {
   if (challenger1Name.value || challenger1Guess.value || challenger2Name.value || challenger2Guess.value){
     clearFormBtn.disabled === false;
+    console.log('clear-btn-not-disabled');
   } else {
     clearFormBtn.disabled=== true;
+    console.log('clear-btn-not-disabled');
   }
 }
 
@@ -46,4 +51,7 @@ function populateLatestGuess(){
   challenger2NameSlot.innerText= challenger2Name.value;
   challenger1GuessSlot.innerText= challenger1Guess.value;
   challenger2GuessSlot.innerText= challenger2Guess.value;
+
+  clearFormInputs();
+
 }

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ var challenger1Name = document.querySelector('#challenger-1-name-input');
 var challenger1Guess = document.querySelector('#challenger-1-guess-input');
 var challenger2Name = document.querySelector('#challenger-2-name-input');
 var challenger2Guess = document.querySelector('#challenger-2-guess-input');
+var resetGameBtn = document.querySelector('#reset-game-btn');
 
 submitGuessForm.addEventListener('input', checkGuessInputs);
 submitGuessForm.addEventListener('input', enableClearBtn);
@@ -17,20 +18,18 @@ function checkGuessInputs(){
 
   if (challenger1Name.value && challenger1Guess.value && challenger2Name.value && challenger2Guess.value){
     submitBtn.disabled === false;
-    console.log('submit-btn-not-disabled');
+
   } else {
     submitBtn.disabled=== true;
-    console.log('submit-btn-not-disabled');
   }
 }
 
 function enableClearBtn() {
   if (challenger1Name.value || challenger1Guess.value || challenger2Name.value || challenger2Guess.value){
     clearFormBtn.disabled === false;
-    console.log('clear-btn-not-disabled');
+
   } else {
     clearFormBtn.disabled=== true;
-    console.log('clear-btn-not-disabled');
   }
 }
 
@@ -53,5 +52,14 @@ function populateLatestGuess(){
   challenger2GuessSlot.innerText= challenger2Guess.value;
 
   clearFormInputs();
+  disableAllSubmitGuessBtns();
 
+}
+
+function disableAllSubmitGuessBtns() {
+  submitBtn.disabled = true;
+  clearFormBtn.disabled = true;
+  resetGameBtn.disabled = true;
+
+  console.log('all btns disabled');
 }


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Detailed Description
Added functionality to the submit guess button so that the form clears after a user has input their guesses and the latest guess section has populated accordingly, and all the buttons are then disabled on the form.

### Why is this change required? What problem does it solve?
It gives a better user experience to see the user's input populated in the latest guess section without also seeing it persisting in the submit guess section as well.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
I wasn't sure if we could use the clearFromInputs function as a helper function, but it worked. Let's check in with our PM regarding if this is conventional or not.

### Files modified:
- [X] index.html
- [ ] styles.css
- [X] main.js
- [ ] Other files:
