### PR TITLE
Feature/winner card and form reset

### DIFF
--- a/main.js
+++ b/main.js
@@ -123,7 +123,7 @@ function clearSetRangeInputs() {
 function displayWinnerCard(){
   var rightSection= document.querySelector('.right-section');
 
-  rightSection.innerHTML+= `
+  rightSection.insertAdjacentHTML('afterbegin', `
   <section class="winner-card">
       <section class="vs">
         <p><span>${challenger1Name.value}</span></p>
@@ -139,5 +139,5 @@ function displayWinnerCard(){
         <p><span>1</span> MINUTE <span>35</span> SECONDS</p>
         <img src="assets/delete.svg" alt="close-icon">
       </section>
-    </section>`
+    </section>`); 
 }

--- a/main.js
+++ b/main.js
@@ -12,6 +12,8 @@ var maxRangeInput = document.querySelector('#max-range-input');
 var minRangeValue = document.querySelector('#min-range-value');
 var maxRangeValue = document.querySelector('#max-range-value');
 var updateBtn = document.querySelector('#update-btn');
+var challenger1GuessSlot= document.querySelector('#challenger-1-guess-slot');
+var challenger2GuessSlot= document.querySelector('#challenger-2-guess-slot');
 var gameWinner
 var targetNum
 var guessCounter= 0;
@@ -50,8 +52,7 @@ function clearFormInputs() {
 function populateLatestGuess(){
   var challenger1NameSlot= document.querySelector('#challenger-1-name-slot');
   var challenger2NameSlot= document.querySelector('#challenger-2-name-slot');
-  var challenger1GuessSlot= document.querySelector('#challenger-1-guess-slot');
-  var challenger2GuessSlot= document.querySelector('#challenger-2-guess-slot');
+
 
   challenger1NameSlot.innerText= challenger1Name.value;
   challenger2NameSlot.innerText= challenger2Name.value;
@@ -148,4 +149,11 @@ function displayWinnerCard(){
 
 function clearGuessCounter(){
   guessCounter=0;
+}
+
+function guessFromReset() {
+  //Set range to display back to 1 to 100
+
+  //Remove pink class from text
+  //reset generateTargetNum
 }

--- a/main.js
+++ b/main.js
@@ -142,3 +142,14 @@ function displayWinnerCard(){
       </section>
     </section>`);
 }
+
+function resetGuessForm() {
+  //set counter back to zero
+  guessCounter = 0;
+  //clear out innerText displaying Range
+  minRangeValue.innerText = 1;
+  maxRangeValue.innerText = 100;
+  //update targetNum - tricky part
+  targetNum = null;
+
+}

--- a/main.js
+++ b/main.js
@@ -14,6 +14,10 @@ var maxRangeValue = document.querySelector('#max-range-value');
 var updateBtn = document.querySelector('#update-btn');
 var challenger1GuessSlot= document.querySelector('#challenger-1-guess-slot');
 var challenger2GuessSlot= document.querySelector('#challenger-2-guess-slot');
+var challenger1Feedback = document.querySelector('#challenger-1-feedback');
+var challenger2Feedback = document.querySelector('#challenger-2-feedback');
+var challenger1NameSlot= document.querySelector('#challenger-1-name-slot');
+var challenger2NameSlot= document.querySelector('#challenger-2-name-slot');
 var gameWinner
 var targetNum
 var guessCounter= 0;
@@ -50,9 +54,6 @@ function clearFormInputs() {
 
 
 function populateLatestGuess(){
-  var challenger1NameSlot= document.querySelector('#challenger-1-name-slot');
-  var challenger2NameSlot= document.querySelector('#challenger-2-name-slot');
-
 
   challenger1NameSlot.innerText= challenger1Name.value;
   challenger2NameSlot.innerText= challenger2Name.value;
@@ -81,9 +82,6 @@ function generateTargetNum(){
 }
 
 function guessChecker(){
-  var challenger1Feedback = document.querySelector('#challenger-1-feedback');
-  var challenger2Feedback = document.querySelector('#challenger-2-feedback');
-
   var highFeedback = ["that's too high!", "guess lower!", "too high!", "go lower!", "not low enough!"];
   var lowFeedback= ["that's too low!", "guess higher!", "too low!", "go higher!", "not high enough!"];
   var index1= Math.floor(Math.random() * highFeedback.length);
@@ -143,7 +141,7 @@ function displayWinnerCard(){
         <p><span>1</span> MINUTE <span>35</span> SECONDS</p>
         <img src="assets/delete.svg" alt="close-icon">
       </section>
-    </section>`
+    </section>`);
   clearGuessCounter();
 }
 
@@ -151,9 +149,25 @@ function clearGuessCounter(){
   guessCounter=0;
 }
 
-function guessFromReset() {
-  //Set range to display back to 1 to 100
+function resetGuessForm() {
+  minRangeValue.innerText = 1;
+  maxRangeValue.innerText = 100;
 
-  //Remove pink class from text
+  challenger1GuessSlot.classList.remove('pink-text');
+  challenger2GuessSlot.classList.remove('pink-text');
+
+  challenger1NameSlot.innerText = 'Challenger 1 Name';
+  challenger2NameSlot.innerText = 'Challenger 2 Name';
+
+  challenger1Feedback.innerText = 'no guesses yet!';
+  challenger2Feedback.innerText = 'no guesses yet!';
+  //disable form buttons
+  // disableAllSubmitGuessBtns()
   //reset generateTargetNum
+  resetTargetNum();
+  console.log({targetNum});
+}
+
+function resetTargetNum() {
+  targetNum = NaN;
 }

--- a/main.js
+++ b/main.js
@@ -12,13 +12,14 @@ var maxRangeInput = document.querySelector('#max-range-input');
 var minRangeValue = document.querySelector('#min-range-value');
 var maxRangeValue = document.querySelector('#max-range-value');
 var updateBtn = document.querySelector('#update-btn');
-var gameWinner
-var targetNum
+var gameWinner;
+var targetNum;
 
 submitGuessForm.addEventListener('input', checkGuessInputs);
 submitGuessForm.addEventListener('input', enableClearBtn);
 clearFormBtn.addEventListener('click', clearFormInputs);
 updateBtn.addEventListener('click', udpateCurrentGuessRange);
+resetGameBtn.addEventListener('click', resetGuessForm);
 
 
 function checkGuessInputs(){
@@ -139,5 +140,5 @@ function displayWinnerCard(){
         <p><span>1</span> MINUTE <span>35</span> SECONDS</p>
         <img src="assets/delete.svg" alt="close-icon">
       </section>
-    </section>`); 
+    </section>`);
 }


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Detailed Description
Instead of using innerHTML to append the winner's cards to the right section of the page, I used insertadjacentHTML in order for the latest winner's card to display as the first card in the column. 

I added functionality to the rest game button, so that it completely resetst the game and clears out all customized datas as follows:
* the range displayed on the form
* the user's names and their respective guesses 
* resets the targetNum

### Why is this change required? What problem does it solve?
The latest winner's card appearing on top is great for user experience so that one can always see who was the most recent winner especially if there are multiple cards on the page.

Functionality on the reset button is required so that once a game is finished, users can restart the game and play again.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Ideally, all the buttons on the submit guess form should also be disabled upon click of the reset button, and then once the game restarts all those buttons should go back to their default functionality. However, I was having trouble setting that up without breaking anything else.

### Files modified:
- [ ] index.html
- [ ] styles.css
- [X] main.js
- [ ] Other files:
