### PR TITLE
Feature/clear cards btn

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
         </section>
       </section>
       <section class="right-section">
+        <button id="clear-all-btn">CLEAR ALL</button>
       </section>
     </main>
   </body>

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
       </section>
       <section class="right-section">
         <button class="clear-all-btn hidden">CLEAR ALL</button>
+        <section class="winner-cards-container"></section>
       </section>
     </main>
   </body>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
         </section>
       </section>
       <section class="right-section">
-        <button id="clear-all-btn">CLEAR ALL</button>
+        <button class="clear-all-btn hidden">CLEAR ALL</button>
       </section>
     </main>
   </body>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,8 @@
       </section>
       <section class="right-section">
         <button class="clear-all-btn hidden">CLEAR ALL</button>
-        <section class="winner-cards-container"></section>
+        <section class="winner-cards-container">
+        </section>
       </section>
     </main>
   </body>

--- a/main.js
+++ b/main.js
@@ -24,6 +24,7 @@ var guessCounter= 0;
 var rightSection= document.querySelector('.right-section');
 var errorMessage= document.querySelector('#warning');
 var setRangeForm= document.querySelector('#set-range-inputs');
+var clearAllBtn = document.querySelector('.clear-all-btn');
 
 submitGuessForm.addEventListener('input', checkGuessInputs);
 submitGuessForm.addEventListener('input', enableClearBtn);
@@ -153,8 +154,17 @@ function displayWinnerCard(){
 }
 
 function showClearAllBtn() {
-  var clearAllBtn = document.querySelector('.clear-all-btn');
+  var rightSection = document.querySelector('.right-section')
   clearAllBtn.classList.remove('hidden');
+  rightSection.addEventListener('click', clearAllWinnerCards);
+}
+
+function clearAllWinnerCards() {
+  var winnerCard = document.querySelectorAll('.winner-card');
+  if (event.target.classList.contains('clear-all-btn')) {
+    event.target.nextElementSibling.remove();
+    clearAllBtn.classList.add('hidden');
+  }
 }
 
 function clearGuessCounter(){

--- a/main.js
+++ b/main.js
@@ -149,6 +149,12 @@ function displayWinnerCard(){
       </section>
     </section>`);
   clearGuessCounter();
+  showClearAllBtn()
+}
+
+function showClearAllBtn() {
+  var clearAllBtn = document.querySelector('.clear-all-btn');
+  clearAllBtn.classList.remove('hidden');
 }
 
 function clearGuessCounter(){

--- a/main.js
+++ b/main.js
@@ -129,9 +129,9 @@ function clearSetRangeInputs() {
 }
 
 function displayWinnerCard(){
-  var rightSection= document.querySelector('.right-section');
+  var winnerCardsContainer= document.querySelector('.winner-cards-container');
 
-  rightSection.insertAdjacentHTML('afterbegin', `
+  winnerCardsContainer.insertAdjacentHTML('afterbegin', `
   <section class="winner-card">
       <section class="vs">
         <p><span>${challenger1Name.value}</span></p>

--- a/styles.css
+++ b/styles.css
@@ -250,7 +250,7 @@ hr {
 .clear-all-btn {
   background-color: #6E6E6E;
   font-size: .6em;
-  margin-left: 85%;
+  margin-left: 83%;
   margin-top: 2%;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -99,7 +99,8 @@ hr {
 }
 
 .set-range-inputs div button,
-.submit-guess form button {
+.submit-guess form button,
+#clear-all-btn {
   background-color: #d0d2d3;
   border: 0;
   border-radius: 15px;
@@ -244,6 +245,11 @@ hr {
 .right-section {
   background-color: #d0d2d3;
   border-left: solid 1px #666666;
+}
+
+#clear-all-btn {
+  background-color: #404041;
+  font-size: .6em;
 }
 
 .winner-card {

--- a/styles.css
+++ b/styles.css
@@ -279,7 +279,7 @@ hr {
 .vs,
 .game-stats {
   height: 15%;
-  padding-top: 1%;
+  padding: 1.5% 0;
 }
 
 .game-stats {
@@ -288,7 +288,7 @@ hr {
 
 .vs {
   justify-content: space-around;
-  padding-bottom: 4%;
+  /* padding-bottom: 4%; */
 }
 
 .winner-declaration {
@@ -298,7 +298,7 @@ hr {
   flex-direction: column;
   font-size: 1.7em;
   line-height: 1em;
-  padding-top: 4%;
+  padding: 4% 0;
   text-align: center;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -100,7 +100,7 @@ hr {
 
 .set-range-inputs div button,
 .submit-guess form button,
-#clear-all-btn {
+.clear-all-btn {
   background-color: #d0d2d3;
   border: 0;
   border-radius: 15px;
@@ -247,7 +247,7 @@ hr {
   border-left: solid 1px #666666;
 }
 
-#clear-all-btn {
+.clear-all-btn {
   background-color: #6E6E6E;
   font-size: .6em;
   margin-left: 85%;

--- a/styles.css
+++ b/styles.css
@@ -248,8 +248,10 @@ hr {
 }
 
 #clear-all-btn {
-  background-color: #404041;
+  background-color: #6E6E6E;
   font-size: .6em;
+  margin-left: 85%;
+  margin-top: 2%;
 }
 
 .winner-card {


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Detailed Description
Created a clear all `<button>` on the right side of the panel to delete all the winner's cards upon click. The button is hidden by default and only appears if there is at least one winner's cards present on the right side of the page.

### Why is this change required? What problem does it solve?
This feature is a "nice to have." After a few winning rounds of the number guesser game, there will be many card displayed on the right side. It is nice to have a feature where a user can elminate all the cards at once if they'd like.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
An initial challenge when implementing this was having the winner's cards prepend to the button. This was handled by creating a separate section to contain only the cards and prepending the cards to that new section.

### Files modified:
- [X] index.html
- [X] styles.css
- [X] main.js
- [ ] Other files:
